### PR TITLE
limit log_queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,39 +8,64 @@ A tcp logger for [Logstash](http://logstash.net/docs/1.4.2/inputs/tcp)
 
 <table>
   <tr>
+    <th></th>
+    <th>type</th>
+    <th>default</th>
+    <th>note</th>
+  </tr>
+  <tr>
     <th>level</th>
     <td>string</td>
     <td><code>info</code></td>
+    <td></td>
   </tr>
   <tr>
     <th>server</th>
     <td>string</td>
     <td><code>os.hostname()</code></td>
+    <td></td>
   </tr>
   <tr>
     <th>host</th>
     <td>string</td>
     <td><code>"127.0.0.1"</code></td>
+    <td></td>
   </tr>
   <tr>
     <th>port</th>
     <td>number</td>
     <td><code>9999</code></td>
+    <td></td>
   </tr>
   <tr>
     <th>application</th>
     <td>string</td>
     <td><code>process.title</code></td>
+    <td></td>
   </tr>
   <tr>
     <th>pid</th>
     <td>string</td>
     <td><code>process.pid</code></td>
+    <td></td>
   </tr>
   <tr>
     <th>tags</th>
     <td>array|string[]</td>
     <td><code>["bunyan"]</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <th>max_connect_retries</th>
+    <td>number</td>
+    <td><code>4</code></td>
+    <td><code>-1</code> for infinite</td>
+  </tr>
+  <tr>
+    <th>max_queued_logs</th>
+    <td>number</td>
+    <td><code>500</code></td>
+    <td><code>0</code> to disable queue when not connected</td>
   </tr>
 </table>
 

--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -9,8 +9,6 @@ var net = require('net'),
     extend = util._extend,
     _ = require('lodash');
 
-var ECONNREFUSED_REGEXP = /ECONNREFUSED/;
-
 var levels = {
   10: 'trace',
   20: 'debug',
@@ -52,6 +50,7 @@ function LogstashStream(options) {
   this.socket = null;
   this.retries = -1;
   this.max_connect_retries = ('number' === typeof options.max_connect_retries) ? options.max_connect_retries : 4;
+  this.max_queued_logs = ('number' === typeof options.max_queued_logs) ? options.max_queued_logs : 500;
 
   this.connect();
 }
@@ -97,7 +96,6 @@ LogstashStream.prototype.write = function logstashWrite(entry) {
 };
 
 LogstashStream.prototype.connect = function () {
-  var tryReconnect = true;
   var options = {};
   var self = this;
   this.retries++;
@@ -131,10 +129,6 @@ LogstashStream.prototype.connect = function () {
     self.connected = false;
     self.socket.destroy();
     self.socket = null;
-
-    if (!ECONNREFUSED_REGEXP.test(err.message)) {
-      tryReconnect = false;
-    }
   });
 
   this.socket.on('timeout', function() {
@@ -156,9 +150,6 @@ LogstashStream.prototype.connect = function () {
           self.connect();
         }, 100);
       }
-    } else {
-      self.log_queue = [];
-      self.silent = true;
     }
   });
 
@@ -194,9 +185,11 @@ LogstashStream.prototype.send = function logstashSend(message) {
 
   // send tcp logs
   if (!self.connected) {
-    self.log_queue.push({
-      message: message,
-    });
+    if (self.log_queue.length < self.max_queued_logs) {
+      self.log_queue.push({
+        message: message,
+      });
+    }
   } else {
     self.sendLog(message);
   }


### PR DESCRIPTION
I need the service always retry even when logstash not started and cache all the logs, so I have to add limitation of queue size.

Besides, `self.silent` and `tryReconnect` seems not used, so I removed them.
