### PR TITLE
call socket.unref()

### DIFF
--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -128,6 +128,7 @@ LogstashStream.prototype.connect = function () {
   } else {
     this.socket = new net.Socket();
   }
+  this.socket.unref();
 
   this.socket.on('error', function (err) {
     self.connecting = false;
@@ -157,7 +158,7 @@ LogstashStream.prototype.connect = function () {
       if (!self.connecting) {
         setTimeout(function () {
           self.connect();
-        }, self.retry_interval);
+        }, self.retry_interval).unref();
       }
     } else {
       self.log_queue = new CBuffer(self.cbuffer_size);


### PR DESCRIPTION
Without `unref`, program will not exit by itself.