### PR TITLE
Wrap `rec.time` in a Date object before calling `toISOString`

### DIFF
--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -79,7 +79,7 @@ LogstashStream.prototype.write = function logstashWrite(entry) {
   }
 
   msg = {
-    '@timestamp': rec.time.toISOString(),
+    '@timestamp': new Date(rec.time).toISOString(),
     'message':    rec.msg,
     'tags':       this.tags,
     'source':     this.server + '/' + this.application,


### PR DESCRIPTION
`rec.time` is already an ISO formatted string for me, so I'd get errors otherwise. Wrapping a Date object in new Date() returns a clone of the same date object, so this doesn't break the case where `rec.time` is a Date