### PR TITLE
Update logstash.js

### DIFF
--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -132,7 +132,10 @@ LogstashStream.prototype.connect = function () {
   } else {
     this.socket = new net.Socket();
   }
-  this.socket.unref();
+
+  if (_.isFunction(this.socket.unref)) {
+    this.socket.unref();
+  }
 
   this.socket.on('error', function (err) {
     self.connecting = false;


### PR DESCRIPTION
Checking if socket.unref exists.  In node 0.10 the CleartextStream object returned by tls.connect doesn't have an unref() function

See https://github.com/chris-rock/bunyan-logstash-tcp/issues/18
